### PR TITLE
adding license to build

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "WebGL"
   ],
   "author": "David Levinsky",
-  "license": "BSD-3-Clause",
+  "license": "BSD-2-Clause",
   "bugs": {
     "url": "https://github.com/melown/melown-js/issues"
   },
@@ -36,6 +36,7 @@
     "extract-text-webpack-plugin": "^2.1.0",
     "html-webpack-plugin": "^2.28.0",
     "install": "^0.8.7",
+    "license-webpack-plugin": "^0.4.3",
     "mocha": "^3.2.0",
     "serve": "^5.0.4",
     "style-loader": "^0.16.1",

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -4,13 +4,18 @@ var CopyWebpackPlugin = require('copy-webpack-plugin');
 var CommonChunks = require('copy-webpack-plugin');
 var UglifyJsPlugin = webpack.optimize.UglifyJsPlugin;
 var ExtractTextPlugin = require("extract-text-webpack-plugin");
+var LicenseWebpackPlugin = require('license-webpack-plugin');
+var fs = require("fs");
+
 
 var PROD = (process.env.NODE_ENV === 'production')
 
 var plugins = [
     new ExtractTextPlugin({
       filename: "melown-browser.css"
-    })
+    }),
+    new LicenseWebpackPlugin({pattern: /^(MIT|ISC|BSD.*)$/}),
+    new webpack.BannerPlugin(fs.readFileSync('./LICENSE', 'utf8'))
 ];
 
 if (PROD) {


### PR DESCRIPTION
* Fixes https://github.com/Melown/melown-js/issues/9
* Introduces `3rdpartylicenses.txt` - file containing all 3rd party licenes found in the build
* Adds license banner to every compiled JavaScript file